### PR TITLE
Fixes bug where saturation is just ignored.

### DIFF
--- a/src/main/java/flaxbeard/cyberware/common/item/ItemLowerOrgansUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemLowerOrgansUpgrade.java
@@ -117,14 +117,7 @@ public class ItemLowerOrgansUpgrade extends ItemCyberware implements IMenuItem
 						int toRemove = getTicksTilRemove(stack);
 						if (!p.isCreative() && toRemove <= 0)
 						{
-							/*if (p.getFoodStats().getSaturationLevel() >= 1F)
-							{
-								p.getFoodStats().setFoodSaturationLevel(p.getFoodStats().getSaturationLevel() - 1);
-							}
-							else
-							{*/
-								p.getFoodStats().setFoodLevel(p.getFoodStats().getFoodLevel() - 1);
-							/*}*/
+							p.getFoodStats().addExhaustion(6F); //You lose the same amount as when a half heart is healed.
 							toRemove = LibConstants.METABOLIC_USES;
 						}
 						else if (toRemove > 0)


### PR DESCRIPTION
This number can be tweaked if you like, but as the comment line says it does exactly the same amount of hunger as when 1 half heart is healed.    
EDIT: Going to add that that math is according to this, https://minecraft.gamepedia.com/Hunger#Exhaustion_level_increase , and I did test myself. I figure you would rather tweak the number yourself though, this just gives a working way to do it.